### PR TITLE
Add rack-cors gem and configure initializer file for localhost access

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
-# gem "rack-cors"
+gem "rack-cors"
 gem "faraday"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.9)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -263,6 +265,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry
   puma (>= 5.0)
+  rack-cors
   rails (~> 7.1.3)
   rspec-rails
   shoulda-matchers (~> 5.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -8,7 +8,8 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "http://localhost:3000",
-            "http://127.0.0.1:3000"
+            "http://127.0.0.1:3000",
+            "https://m4-parks-backend.onrender.com"
 
             # "http://yourwebsite.production.app" frontend deploy URL
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,15 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://localhost:3000",
+            "http://127.0.0.1:3000"
+
+            # "http://yourwebsite.production.app" frontend deploy URL
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :options, :head]
+  end
+end


### PR DESCRIPTION
#### Updates Made -
- Type of change: Install GEM
- Database/Migrations: n/a
- Routes: n/a
- Models: n/a
- Controllers: n/a
- API/JSON: n/a
- Testing:
  - Models: Tests pass
  - Features: Tests pass
- Considerations(Extra notes, refactors, etc.): Uncommented rack-core gem in gem file. Added base configuration to config/initializers/cors.rb. I only added access from localhost 3000. The deployed frontend address will need to be added once it is deployed. I restricted actions to GET for now.